### PR TITLE
Split Randomized Benchmarking fidelity tables into two columns

### DIFF
--- a/report.tex
+++ b/report.tex
@@ -404,111 +404,295 @@ QML: Yeast 3q & Accuracy & 0.63 & 144.28 sec \\  % & 8, 3, 2
 
 \section{Randomized Benchmarking Results}
 
-\begin{multicols}{2}
-
 %\subsection{New Fidelities}
+\noindent\begin{minipage}{0.48\textwidth}
+\noindent\begin{minipage}[t]{0.48\linewidth}
 \begin{center}
 \begin{tabular}{@{}c c c@{}}
 \toprule
 Qubit n & Fidelity & Error Bars \\ \midrule
 
+
 0 & 0.997 & $\pm$ 0.00041 \\
+
+
 
 1 & \textcolor{green}{0.998} & $\pm$ 0.0006 \\
 
+
+
 2 & 0.996 & $\pm$ 0.000236 \\
+
+
 
 3 & \textcolor{green}{0.998} & $\pm$ 0.000236 \\
 
+
+
 4 & 0.995 & $\pm$ 0.000486 \\
+
+
 
 5 & 0.996 & $\pm$ 0.000826 \\
 
+
+
 6 & \textcolor{green}{0.999} & $\pm$ 0.000308 \\
+
+
 
 7 & 0.983 & $\pm$ 0.00219 \\
 
+
+
 8 & 0.995 & $\pm$ 0.00054 \\
+
+
 
 9 & 0.996 & $\pm$ 0.000782 \\
 
-10 & 0.995 & $\pm$ 0.000441 \\
 
-11 & \textcolor{green}{0.998} & $\pm$ 0.000246 \\
 
-12 & \textcolor{green}{0.998} & $\pm$ 0.000396 \\
 
-13 & \textcolor{green}{0.998} & $\pm$ 0.000344 \\
 
-14 & 0.997 & $\pm$ 0.000357 \\
 
-15 & 0.995 & $\pm$ 0.000647 \\
 
-16 & 0.997 & $\pm$ 0.000463 \\
 
-17 & 0.991 & $\pm$ 0.0006 \\
 
-18 & 0.987 & $\pm$ 0.00163 \\
 
-19 & \textcolor{green}{0.998} & $\pm$ 0.00042 \\
+
+
+
+
+
+
+
+
+
+
+
 
 \bottomrule
 \end{tabular}
 \end{center}
+\end{minipage}%
+\hfill%
+\begin{minipage}[t]{0.48\linewidth}
+\begin{center}
+\begin{tabular}{@{}c c c@{}}
+\toprule
+Qubit n & Fidelity & Error Bars \\ \midrule
 
-\columnbreak
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+10 & 0.995 & $\pm$ 0.000441 \\
+
+
+
+11 & \textcolor{green}{0.998} & $\pm$ 0.000246 \\
+
+
+
+12 & \textcolor{green}{0.998} & $\pm$ 0.000396 \\
+
+
+
+13 & \textcolor{green}{0.998} & $\pm$ 0.000344 \\
+
+
+
+14 & 0.997 & $\pm$ 0.000357 \\
+
+
+
+15 & 0.995 & $\pm$ 0.000647 \\
+
+
+
+16 & 0.997 & $\pm$ 0.000463 \\
+
+
+
+17 & 0.991 & $\pm$ 0.0006 \\
+
+
+
+18 & 0.987 & $\pm$ 0.00163 \\
+
+
+
+19 & \textcolor{green}{0.998} & $\pm$ 0.00042 \\
+
+
+\bottomrule
+\end{tabular}
+\end{center}
+\end{minipage}
+\end{minipage}%
+\hfill%
 %\subsection{Control Fidelities}
+\begin{minipage}{0.48\textwidth}
+\noindent\begin{minipage}[t]{0.48\linewidth}
 \begin{center}
 \begin{tabular}{@{}c c c@{}}
 \toprule
 Qubit n & Fidelity & Error Bars \\ \midrule
 
+
 0 & 0.997 & $\pm$ 0.00041 \\
+
+
 
 1 & \textcolor{green}{0.998} & $\pm$ 0.0006 \\
 
+
+
 2 & 0.996 & $\pm$ 0.000236 \\
+
+
 
 3 & \textcolor{green}{0.998} & $\pm$ 0.000236 \\
 
+
+
 4 & 0.995 & $\pm$ 0.000486 \\
+
+
 
 5 & 0.996 & $\pm$ 0.000826 \\
 
+
+
 6 & \textcolor{green}{0.999} & $\pm$ 0.000308 \\
+
+
 
 7 & 0.983 & $\pm$ 0.00219 \\
 
+
+
 8 & 0.995 & $\pm$ 0.00054 \\
+
+
 
 9 & 0.996 & $\pm$ 0.000782 \\
 
-10 & 0.995 & $\pm$ 0.000441 \\
 
-11 & \textcolor{green}{0.998} & $\pm$ 0.000246 \\
 
-12 & \textcolor{green}{0.998} & $\pm$ 0.000396 \\
 
-13 & \textcolor{green}{0.998} & $\pm$ 0.000344 \\
 
-14 & 0.997 & $\pm$ 0.000357 \\
 
-15 & 0.995 & $\pm$ 0.000647 \\
 
-16 & 0.997 & $\pm$ 0.000463 \\
 
-17 & 0.991 & $\pm$ 0.0006 \\
 
-18 & 0.987 & $\pm$ 0.00163 \\
 
-19 & \textcolor{green}{0.998} & $\pm$ 0.00042 \\
+
+
+
+
+
+
+
+
+
+
+
 
 \bottomrule
 \end{tabular}
 \end{center}
+\end{minipage}%
+\hfill%
+\begin{minipage}[t]{0.48\linewidth}
+\begin{center}
+\begin{tabular}{@{}c c c@{}}
+\toprule
+Qubit n & Fidelity & Error Bars \\ \midrule
 
-\end{multicols}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+10 & 0.995 & $\pm$ 0.000441 \\
+
+
+
+11 & \textcolor{green}{0.998} & $\pm$ 0.000246 \\
+
+
+
+12 & \textcolor{green}{0.998} & $\pm$ 0.000396 \\
+
+
+
+13 & \textcolor{green}{0.998} & $\pm$ 0.000344 \\
+
+
+
+14 & 0.997 & $\pm$ 0.000357 \\
+
+
+
+15 & 0.995 & $\pm$ 0.000647 \\
+
+
+
+16 & 0.997 & $\pm$ 0.000463 \\
+
+
+
+17 & 0.991 & $\pm$ 0.0006 \\
+
+
+
+18 & 0.987 & $\pm$ 0.00163 \\
+
+
+
+19 & \textcolor{green}{0.998} & $\pm$ 0.00042 \\
+
+
+\bottomrule
+\end{tabular}
+\end{center}
+\end{minipage}
+\end{minipage}
 
 \newpage
 

--- a/src/templates/report_template.j2
+++ b/src/templates/report_template.j2
@@ -376,35 +376,71 @@ Amplitude Encoding &  -  &  -  & {{ right.amplitude_encoding_runtime | default('
 
 \section{Randomized Benchmarking Results}
 
-\begin{multicols}{2}
-
 %\subsection{New Fidelities}
+\noindent\begin{minipage}{0.48\textwidth}
+\noindent\begin{minipage}[t]{0.48\linewidth}
 \begin{center}
 \begin{tabular}{@{}c c c@{}}
 \toprule
 Qubit n & Fidelity & Error Bars \\ \midrule
 {% for row in left.fidelities_list %}
+{% if loop.index <= 10 %}
 {{ row.qn }} & {{ row.fidelity }} & $\pm$ {{ row.error_bars }} \\
+{% endif %}
 {% endfor %}
 \bottomrule
 \end{tabular}
 \end{center}
-
-\columnbreak
-
+\end{minipage}%
+\hfill%
+\begin{minipage}[t]{0.48\linewidth}
+\begin{center}
+\begin{tabular}{@{}c c c@{}}
+\toprule
+Qubit n & Fidelity & Error Bars \\ \midrule
+{% for row in left.fidelities_list %}
+{% if loop.index > 10 %}
+{{ row.qn }} & {{ row.fidelity }} & $\pm$ {{ row.error_bars }} \\
+{% endif %}
+{% endfor %}
+\bottomrule
+\end{tabular}
+\end{center}
+\end{minipage}
+\end{minipage}%
+\hfill%
 %\subsection{Control Fidelities}
+\begin{minipage}{0.48\textwidth}
+\noindent\begin{minipage}[t]{0.48\linewidth}
 \begin{center}
 \begin{tabular}{@{}c c c@{}}
 \toprule
 Qubit n & Fidelity & Error Bars \\ \midrule
 {% for row in right.fidelities_list %}
+{% if loop.index <= 10 %}
 {{ row.qn }} & {{ row.fidelity }} & $\pm$ {{ row.error_bars }} \\
+{% endif %}
 {% endfor %}
 \bottomrule
 \end{tabular}
 \end{center}
-
-\end{multicols}
+\end{minipage}%
+\hfill%
+\begin{minipage}[t]{0.48\linewidth}
+\begin{center}
+\begin{tabular}{@{}c c c@{}}
+\toprule
+Qubit n & Fidelity & Error Bars \\ \midrule
+{% for row in right.fidelities_list %}
+{% if loop.index > 10 %}
+{{ row.qn }} & {{ row.fidelity }} & $\pm$ {{ row.error_bars }} \\
+{% endif %}
+{% endfor %}
+\bottomrule
+\end{tabular}
+\end{center}
+\end{minipage}
+\end{minipage}
 
 \newpage
 


### PR DESCRIPTION
## Summary

- Split the left and right fidelity tables in the Randomized Benchmarking section into two sub-columns each (rows 1–10 and 11+) to reduce vertical space
- Uses nested minipages with a small inner gap between sub-columns and a larger gap between left/right sides

## Test plan

- Run report generation and verify fidelity tables render in a compact 2-column layout
- Confirm the left vs right separation is visually clear