### PR TITLE
Fix statistics table sourcing + add 2-qubit metrics

### DIFF
--- a/scripts/report.sh
+++ b/scripts/report.sh
@@ -11,6 +11,8 @@ RUNID_RIGHT="${RUNID_RIGHT:-20251123023814}"
 calibration_left="${calibration_left:-3826882f81128980b5e49b0e1bec76e24e40e158}"
 RUNID_LEFT="${RUNID_LEFT:-20251201101512}"
 
+SHOW_ERRORS="${SHOW_ERRORS:-false}"
+
 PYTHON=".venv/bin/python"   # ensures uv environment is used
 LATEX="pdflatex"
 DATESTAMP=$(date +%d%m%Y_%H)
@@ -60,12 +62,18 @@ build() {
     mkdir -p build
     cp src/templates/placeholder.png build/placeholder.png
 
+    ERRORS_FLAG=""
+    if [ "$SHOW_ERRORS" = "false" ]; then
+        ERRORS_FLAG="--no-show-errors"
+    fi
+
     echo "Building LaTeX report..."
     $PYTHON src/main.py \
         --calibration-left "$calibration_left" \
         --calibration-right "$calibration_right" \
         --run-left "$RUNID_LEFT" \
         --run-right "$RUNID_RIGHT" \
+        $ERRORS_FLAG
         # --no-tomography-plot
 }
 

--- a/src/fillers.py
+++ b/src/fillers.py
@@ -283,35 +283,31 @@ def context_fidelity(experiment_dir):
 
 def get_stat_fidelity(raw_data, experiment_dir):
     """
-    Returns a dictionary with average, min, max, and median fidelity for the given experiment directory.
+    Returns a dictionary with average, min, max, and median RB fidelity
+    from calibration.json's single_qubits section.
     """
-
     with open(raw_data, "r") as f:
         results = json.load(f)
 
-    fidelities = results.get('"fidelity"', {})
-    # Convert dict_values to list and flatten if needed
-    fidelities_list = list(fidelities.values())
-
-    # Convert all values to float if possible
+    single_qubits = results.get("single_qubits", {})
     numeric_fidelities = []
-    for f in fidelities_list:
-        try:
-            numeric_fidelities.append(float(f))
-        except (ValueError, TypeError):
-            continue
+    for qubit_data in single_qubits.values():
+        rb_fidelity = qubit_data.get("rb_fidelity", [])
+        if rb_fidelity and rb_fidelity[0] is not None:
+            try:
+                numeric_fidelities.append(float(rb_fidelity[0]))
+            except (ValueError, TypeError):
+                continue
 
     if not numeric_fidelities:
-        return {"average": None, "min": None, "max": None, "median": None}
+        return {"average": "-", "min": "-", "max": "-", "median": "-"}
 
-    dict_fidelities = {
+    return {
         "average": f"{np.nanmean(numeric_fidelities):.3g}",
         "min": f"{np.nanmin(numeric_fidelities):.3g}",
         "max": f"{np.nanmax(numeric_fidelities):.3g}",
         "median": f"{np.nanmedian(numeric_fidelities):.3g}",
     }
-
-    return dict_fidelities
 
 
 def get_stat_t12(experiment_dir, stat_type):
@@ -347,6 +343,137 @@ def get_stat_t12(experiment_dir, stat_type):
         "median": f"{np.nanmedian(numeric_ts):.3g}",
     }
     return dict_ts
+
+
+def _empty_stats():
+    """Placeholder function until it is clear which 2qubit statistics data is to be sourced from results.json."""
+    return {"average": "-", "min": "-", "max": "-", "median": "-"}
+
+
+def _compute_stats(values):
+    numeric = []
+    for v in values:
+        if v is not None:
+            try:
+                numeric.append(float(v))
+            except (ValueError, TypeError):
+                continue
+    if not numeric:
+        return _empty_stats()
+    return {
+        "average": f"{np.nanmean(numeric):.3g}",
+        "min": f"{np.nanmin(numeric):.3g}",
+        "max": f"{np.nanmax(numeric):.3g}",
+        "median": f"{np.nanmedian(numeric):.3g}",
+    }
+
+
+def get_stat_two_qubit(raw_data, metric, show_errors=True):
+    """
+    Returns statistics with error propagation for a 2-qubit metric from calibration.json.
+    Metrics: 'rb_fidelity', 'cz_fidelity', 'coupling'.
+    For rb_fidelity/cz_fidelity: each pair has [value, error].
+    For coupling: each pair has a direct value (often null).
+    """
+    with open(raw_data, "r") as f:
+        results = json.load(f)
+
+    two_qubits = results.get("two_qubits", {})
+
+    values = []
+    errors = []
+    for pair_data in two_qubits.values():
+        entry = pair_data.get(metric)
+        if entry is None:
+            continue
+        if isinstance(entry, list) and len(entry) >= 2:
+            if entry[0] is not None:
+                values.append(float(entry[0]))
+                errors.append(float(entry[1]) if entry[1] is not None else 0.0)
+        else:
+            if entry is not None:
+                try:
+                    values.append(float(entry))
+                    errors.append(0.0)
+                except (ValueError, TypeError):
+                    continue
+
+    if not values:
+        return _empty_stats()
+
+    values = np.array(values)
+    errors = np.array(errors)
+    n = len(values)
+
+    avg_val = np.nanmean(values)
+    avg_err = np.sqrt(np.sum(errors**2)) / n
+
+    min_idx = np.nanargmin(values)
+    min_val = values[min_idx]
+    min_err = errors[min_idx]
+
+    max_idx = np.nanargmax(values)
+    max_val = values[max_idx]
+    max_err = errors[max_idx]
+
+    sorted_indices = np.argsort(values)
+    median_idx = sorted_indices[n // 2]
+    median_val = np.nanmedian(values)
+    median_err = errors[median_idx]
+
+    def fmt(val, err):
+        if not show_errors or err == 0.0:
+            return f"{val:.3g}"
+        return f"{val:.3g} ± {err:.3g}"
+
+    return {
+        "average": fmt(avg_val, avg_err),
+        "min": fmt(min_val, min_err),
+        "max": fmt(max_val, max_err),
+        "median": fmt(median_val, median_err),
+    }
+
+
+def get_stat_t12_from_run(base_dir, calibration_id, run_id, stat_type):
+    """
+    Returns T1 or T2 statistics from the coherence experiment results.json.
+    """
+    results_path = Path(base_dir) / calibration_id / run_id / "coherence" / "results.json"
+    try:
+        with open(results_path, "r") as f:
+            results = json.load(f)
+        values = results.get(stat_type, {}).values()
+        return _compute_stats(values)
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return _empty_stats()
+
+
+def get_stat_fidelity_from_run(base_dir, calibration_id, run_id):
+    """
+    Returns fidelity statistics from the standard_rb experiment results.json.
+    """
+    results_path = Path(base_dir) / calibration_id / run_id / "standard_rb" / "results.json"
+    try:
+        with open(results_path, "r") as f:
+            results = json.load(f)
+        values = results.get("fidelity", {}).values()
+        return _compute_stats(values)
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return _empty_stats()
+
+
+def get_readout_fidelity_from_run(base_dir, calibration_id, run_id):
+    """
+    Returns readout fidelity statistics from the readout experiment results.json.
+    """
+    results_path = Path(base_dir) / calibration_id / run_id / "readout" / "results.json"
+    try:
+        with open(results_path, "r") as f:
+            results = json.load(f)
+        values = results.get("readout_fidelity", {}).values()
+        return _compute_stats(values)
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return _empty_stats()
 
 
 def get_stat_pulse_fidelity(experiment_dir):

--- a/src/main.py
+++ b/src/main.py
@@ -84,6 +84,14 @@ def setup_argument_parser():
         help="Run id for the left experiment.",
     )
 
+    parser.add_argument(
+        "--no-show-errors",
+        dest="show_errors",
+        default=True,
+        action="store_false",
+        help="Hide error bars (±) in 2-qubit statistics.",
+    )
+
     # Plot toggles (default: True). Use --no-<flag> to disable.
     parser.add_argument(
         "--no-t1-plot", dest="t1_plot", default=False, action="store_false"
@@ -209,7 +217,7 @@ def prepare_template_context(cfg):
 
     ##### T1 statistics
     try:
-        stat_t1 = fl.get_stat_t12("calibrations/"+cfg.calibration_left + "/sinq20", "t1")
+        stat_t1 = fl.get_stat_t12_from_run(cfg.base_dir, cfg.calibration_left, cfg.run_left, "t1")
         stat_t1_right = fl.get_stat_t12("calibrations/"+cfg.calibration_right + "/sinq20", "t1")
         stat_t1_with_improvement = add_stat_changes(stat_t1, stat_t1_right)
 
@@ -226,7 +234,7 @@ def prepare_template_context(cfg):
     ##### T2 statistics
     try:    
         """Prepare T2 statistics for both experiments."""
-        stat_t2 = fl.get_stat_t12("calibrations/" + cfg.calibration_left + "/sinq20", "t2")
+        stat_t2 = fl.get_stat_t12_from_run(cfg.base_dir, cfg.calibration_left, cfg.run_left, "t2")
         stat_t2_right = fl.get_stat_t12("calibrations/" + cfg.calibration_right + "/sinq20", "t2")
         stat_t2_with_improvement = add_stat_changes(stat_t2, stat_t2_right)
 
@@ -243,10 +251,7 @@ def prepare_template_context(cfg):
     ##### FIDELITY 
     try:
         """Prepare fidelity statistics for both experiments."""
-        stat_fidelity = fl.get_stat_fidelity(
-            os.path.join("data", "calibrations", cfg.calibration_left, "sinq20", "calibration.json"),
-            cfg.calibration_left,
-        )
+        stat_fidelity = fl.get_stat_fidelity_from_run(cfg.base_dir, cfg.calibration_left, cfg.run_left)
         stat_fidelity_right = fl.get_stat_fidelity(
             os.path.join("data", "calibrations", cfg.calibration_right, "sinq20", "calibration.json"),
             cfg.calibration_right,
@@ -265,10 +270,7 @@ def prepare_template_context(cfg):
     ##### READOUT FIDELITY
     try:
         """Prepare readout fidelity statistics for both experiments."""
-        stat_readout_fidelity = fl.get_readout_fidelity(
-            os.path.join("data", "calibrations", cfg.calibration_left, "sinq20", "calibration.json"),
-            cfg.calibration_left,
-        )
+        stat_readout_fidelity = fl.get_readout_fidelity_from_run(cfg.base_dir, cfg.calibration_left, cfg.run_left)
         stat_readout_fidelity_right = fl.get_readout_fidelity(
             os.path.join("data", "calibrations", cfg.calibration_right, "sinq20", "calibration.json"),
             cfg.calibration_right,
@@ -283,7 +285,20 @@ def prepare_template_context(cfg):
         # context = context_mermin_table(context, cfg)
         # context = context_pulse_fidelity_statistics(context, cfg)
 
-
+    ##### 2-QUBIT STATISTICS (rb_fidelity, cz_fidelity, coupling)
+    calibration_right_path = os.path.join(
+        "data", "calibrations", cfg.calibration_right, "sinq20", "calibration.json"
+    )
+    for metric in ["rb_fidelity", "cz_fidelity", "coupling"]:
+        ctx_key = f"stat_2q_{metric}"
+        try:
+            context["left"][ctx_key] = fl._empty_stats()
+            context["right"][ctx_key] = fl.get_stat_two_qubit(calibration_right_path, metric, show_errors=cfg.show_errors)
+            logging.info(f"Prepared 2Q {metric} statistics")
+        except Exception as e:
+            logging.error(f"Error preparing 2Q {metric} statistics: {e}")
+            context["left"][ctx_key] = fl._empty_stats()
+            context["right"][ctx_key] = fl._empty_stats()
 
     # FIDELITY PLOT MAIN PAGE
     try:

--- a/src/templates/report_template.j2
+++ b/src/templates/report_template.j2
@@ -201,7 +201,10 @@ The single qubit fidelity is obtained via Randomized-Benchmarking. The two-qubit
 T1 (ns) & {{ left.stat_t1.average }} & {{ left.stat_t1.median }} & {{ left.stat_t1.min }} & {{ left.stat_t1.max }} \\
 T2 (ns) & {{ left.stat_t2.average }} & {{ left.stat_t2.median }} & {{ left.stat_t2.min }} & {{ left.stat_t2.max }} \\
 Fidelity & {{ left.stat_fidelity.average }} & {{ left.stat_fidelity.median }} & {{ left.stat_fidelity.min }} & {{ left.stat_fidelity.max }} \\
-RO fidelity  & {{ left.stat_readout_fidelity.average }} & {{ left.stat_readout_fidelity.median }} & {{ left.stat_readout_fidelity.min }} & {{ left.stat_readout_fidelity.max }} \\
+RO Fidelity  & {{ left.stat_readout_fidelity.average }} & {{ left.stat_readout_fidelity.median }} & {{ left.stat_readout_fidelity.min }} & {{ left.stat_readout_fidelity.max }} \\
+2q RB Fidelity & {{ left.stat_2q_rb_fidelity.average }} & {{ left.stat_2q_rb_fidelity.median }} & {{ left.stat_2q_rb_fidelity.min }} & {{ left.stat_2q_rb_fidelity.max }} \\
+2q CZ Fidelity & {{ left.stat_2q_cz_fidelity.average }} & {{ left.stat_2q_cz_fidelity.median }} & {{ left.stat_2q_cz_fidelity.min }} & {{ left.stat_2q_cz_fidelity.max }} \\
+%2q Coupling & {{ left.stat_2q_coupling.average }} & {{ left.stat_2q_coupling.median }} & {{ left.stat_2q_coupling.min }} & {{ left.stat_2q_coupling.max }} \\
 %Mermin Max  & {{ left.mermin_maximum | default('N/A') }} & & & \\
 \bottomrule
 \end{tabular}
@@ -220,6 +223,9 @@ T1 (ns) & {{ right.stat_t1.average }} & {{ right.stat_t1.median }} & {{ right.st
 T2 (ns) & {{ right.stat_t2.average }} & {{ right.stat_t2.median }} & {{ right.stat_t2.min }} & {{ right.stat_t2.max }} \\
 Fidelity  & {{ right.stat_fidelity.average }} & {{ right.stat_fidelity.median }} & {{ right.stat_fidelity.min }} & {{ right.stat_fidelity.max }} \\
 RO Fidelity  & {{ right.stat_readout_fidelity.average }} & {{ right.stat_readout_fidelity.median }} & {{ right.stat_readout_fidelity.min }} & {{ right.stat_readout_fidelity.max }} \\
+2q RB Fidelity & {{ right.stat_2q_rb_fidelity.average }} & {{ right.stat_2q_rb_fidelity.median }} & {{ right.stat_2q_rb_fidelity.min }} & {{ right.stat_2q_rb_fidelity.max }} \\
+2q CZ Fidelity & {{ right.stat_2q_cz_fidelity.average }} & {{ right.stat_2q_cz_fidelity.median }} & {{ right.stat_2q_cz_fidelity.min }} & {{ right.stat_2q_cz_fidelity.max }} \\
+%2q Coupling & {{ right.stat_2q_coupling.average }} & {{ right.stat_2q_coupling.median }} & {{ right.stat_2q_coupling.min }} & {{ right.stat_2q_coupling.max }} \\
 %Mermin Max  & {{ right.mermin_maximum | default('N/A') }} & & & \\
 \bottomrule
 \end{tabular}


### PR DESCRIPTION
### Summary

- **Left column now shows current run data.** T1, T2, Fidelity, and RO Fidelity in the left Statistics table are sourced from the experiment's own result files (`coherence/`, `standard_rb/`, `readout/`) instead of `calibration.json`, which was causing both columns to show identical values.
    
- **Fixed right column Fidelity always showing None.** `get_stat_fidelity()` had a malformed JSON key (`'"fidelity"'`) that never matched anything. Rewrote it to correctly read `rb_fidelity` from the `single_qubits` section of `calibration.json`.
    
- **Added 2-qubit statistics rows.** New rows `2q RB Fidelity` and `2q CZ Fidelity` appear in both tables, sourced from the `two_qubits` section of `calibration.json`. Left column shows `-` as 2 qubit experiment data source still needs to be wired in correctly by looking at file structure in nqch-deploy. A `2q Coupling` row is computed but commented out in the template pending a decision on its data source.
    
- **Error bars toggle.** Stats include propagated errors (`value ± error`). Hidden by default; set `SHOW_ERRORS=true` when calling `report.sh` to display them.
   
   Eg. 
   `SHOW_ERRORS=true calibration_left=1e1f7e1d1af58009eda1986bb3689e6b9b2356b6 RUNID_LEFT=20251123023814 calibration_right=1e1f7e1d1af58009eda1986bb3689e6b9b2356b6 RUNID_RIGHT=20251123023814 ./scripts/report.sh pdf
`

### Files changed

`src/fillers.py` · `src/main.py` · `src/templates/report_template.j2` · `scripts/report.sh`