### PR TITLE
fix bug in report generating for edge cases

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -211,6 +211,7 @@ def prepare_template_context(cfg):
             "platform": "Unknown",
             "start_time": "Unknown",
             "end_time": "Unknown",
+            "versions": {},
         }
         context.setdefault("left", {}).update(default_meta)
         context.setdefault("right", {}).update(default_meta)

--- a/src/prepare_context.py
+++ b/src/prepare_context.py
@@ -102,7 +102,7 @@ def context_version_extractor(context, cfg):
             context[label]["calibration_date"] = file.get("commit_date", "Unknown")
             context[label]["calibration_note"] = file.get("commit_message", "N/A")
 
-            context[label]["versions"] = file.get("versions", "N/A")
+            context[label]["versions"] = file.get("versions", {})
 
             context[label]["run_id"] = file.get("run_id", "N/A")
             context[label]["run_date"] = file.get("experiment_date", "Unknown")


### PR DESCRIPTION
## Summary

- `src/main.py`: added `"versions": {}` to the `default_meta` fallback used when `version_extractor/results.json` is missing — prevents template crash when a run has no version data
- `src/prepare_context.py`: changed `file.get("versions", "N/A")` to `file.get("versions", {})` — prevents the same crash when the file exists but the `versions` key is absent

## Root cause

The Jinja2 template calls `.items()` on `left["versions"]`, expecting a dict. When a partial upload is missing `version_extractor/results.json`, the fallback left `versions` either unset or as the string `"N/A"`, causing an `UndefinedError` that aborted the entire PDF render.

## Test

Verified locally with run `44a690428e4e7e478965661e456986232914ef40 / 20260315232309` (partial upload, only calibration data). PDF now generates successfully with missing experiments handled gracefully.